### PR TITLE
Add Redis-Based JWT blacklist to matching service

### DIFF
--- a/matching-service/src/auth/authentication_agent_types.d.ts
+++ b/matching-service/src/auth/authentication_agent_types.d.ts
@@ -16,7 +16,6 @@ declare type TokenUserData = {
 
 declare type TokenPayload = {
   user: TokenUserData;
-  uuid: string;
 };
 
 export {

--- a/matching-service/src/auth/token_blacklist.ts
+++ b/matching-service/src/auth/token_blacklist.ts
@@ -1,30 +1,32 @@
+import { IRedisAuthAdapter } from '../redis_adapter/redis_auth_adapter';
 import { ITokenBlacklist } from './authentication_agent_types';
 
 /*
 This class will be changed from a memory-based implementation to a Redis-based implementation.
 */
 class TokenBlacklist implements ITokenBlacklist {
-  blacklistSet: Set<string>;
+  redisAdapter: IRedisAuthAdapter;
 
-  constructor() {
-    this.blacklistSet = new Set<string>();
+  constructor(redisAdapter: IRedisAuthAdapter) {
+    this.redisAdapter = redisAdapter;
   }
 
   async addToken(token: string): Promise<boolean> {
-    this.blacklistSet.add(token);
+    await this.redisAdapter.addTokenBlacklist(token);
     return true;
   }
 
   async isTokenBlacklisted(token: string): Promise<boolean> {
-    return this.blacklistSet.has(token);
+    const isBlacklisted = await this.redisAdapter.isTokenBlacklisted(token);
+    return isBlacklisted;
   }
 
   async removeToken(token: string): Promise<boolean> {
-    this.blacklistSet.delete(token);
+    await this.redisAdapter.removeTokenBlacklist(token);
     return true;
   }
 }
 
-export default function createTokenBlacklist(): ITokenBlacklist {
-  return new TokenBlacklist();
+export default function createTokenBlacklist(redisAdapter: IRedisAuthAdapter): ITokenBlacklist {
+  return new TokenBlacklist(redisAdapter);
 }

--- a/matching-service/src/controller/matching_service_controller.ts
+++ b/matching-service/src/controller/matching_service_controller.ts
@@ -12,7 +12,7 @@ import { fromApiHandler } from '../api_server/api_server_helpers';
 import JoinQueueHandler from './matching_service_handlers/join_queue_handler';
 import CheckQueueStatusHandler from './matching_service_handlers/check_status_handler';
 import { IAuthenticationAgent } from '../auth/authentication_agent_types';
-import { IRedisAdapter } from '../redis/redis_adapter';
+import { IRedisMatchingAdapter } from '../redis_adapter/redis_matching_adapter';
 
 class MatchingServiceApi implements ApiService<IQueueService> {
   serviceHandlerDefinition: ServiceHandlerDefinition<IQueueService>;
@@ -21,7 +21,7 @@ class MatchingServiceApi implements ApiService<IQueueService> {
 
   serviceImplementation: IQueueService;
 
-  constructor(authService: IAuthenticationAgent, redisAdapter: IRedisAdapter) {
+  constructor(authService: IAuthenticationAgent, redisAdapter: IRedisMatchingAdapter) {
     const handlerDefinitions: ServiceHandlerDefinition<IQueueService> = {
       joinQueue: fromApiHandler(
         new JoinQueueHandler(authService, redisAdapter),

--- a/matching-service/src/controller/matching_service_handlers/check_status_handler.ts
+++ b/matching-service/src/controller/matching_service_handlers/check_status_handler.ts
@@ -6,15 +6,15 @@ import {
 } from '../../proto/matching-service';
 import { IApiHandler } from '../../api_server/api_server_types';
 import { IAuthenticationAgent } from '../../auth/authentication_agent_types';
-import { IRedisAdapter } from '../../redis/redis_adapter';
+import { IRedisMatchingAdapter } from '../../redis_adapter/redis_matching_adapter';
 
 class CheckQueueStatusHandler implements
   IApiHandler<CheckQueueStatusRequest, CheckQueueStatusResponse> {
   authService: IAuthenticationAgent;
 
-  redisClient: IRedisAdapter;
+  redisClient: IRedisMatchingAdapter;
 
-  constructor(authService: IAuthenticationAgent, redisClient: IRedisAdapter) {
+  constructor(authService: IAuthenticationAgent, redisClient: IRedisMatchingAdapter) {
     this.authService = authService;
     this.redisClient = redisClient;
   }

--- a/matching-service/src/controller/matching_service_handlers/join_queue_handler.ts
+++ b/matching-service/src/controller/matching_service_handlers/join_queue_handler.ts
@@ -1,14 +1,14 @@
 import { JoinQueueErrorCode, JoinQueueRequest, JoinQueueResponse } from '../../proto/matching-service';
 import { IApiHandler } from '../../api_server/api_server_types';
 import { IAuthenticationAgent } from '../../auth/authentication_agent_types';
-import { IRedisAdapter } from '../../redis/redis_adapter';
+import { IRedisMatchingAdapter } from '../../redis_adapter/redis_matching_adapter';
 
 class JoinQueueHandler implements IApiHandler<JoinQueueRequest, JoinQueueResponse> {
   authService: IAuthenticationAgent;
 
-  redisAdapter: IRedisAdapter;
+  redisAdapter: IRedisMatchingAdapter;
 
-  constructor(authService: IAuthenticationAgent, redisClient: IRedisAdapter) {
+  constructor(authService: IAuthenticationAgent, redisClient: IRedisMatchingAdapter) {
     this.authService = authService;
     this.redisAdapter = redisClient;
   }

--- a/matching-service/src/index.ts
+++ b/matching-service/src/index.ts
@@ -1,26 +1,35 @@
 import { Request, Response } from 'express';
+import { createClient, RedisClientType } from 'redis';
 
 import getApiServer from './api_server/api_server';
 import loadEnvironment from './utils/env_loader';
 import { IAuthenticationAgent } from './auth/authentication_agent_types';
 import createAuthenticationService from './auth/authentication_agent';
 import MatchingServiceApi from './controller/matching_service_controller';
-import { createRedisAdapter } from './redis/redis_adapter';
+import { createRedisMatchingAdapter } from './redis_adapter/redis_matching_adapter';
+import { createRedisAuthAdapter } from './redis_adapter/redis_auth_adapter';
 
 const envConfig = loadEnvironment();
 
-const apiServer = getApiServer(envConfig.HTTP_PORT, envConfig.GRPC_PORT);
-const expressApp = apiServer.getHttpServer();
+const redisClient: RedisClientType = createClient({
+  url: envConfig.REDIS_SERVER_URL,
+});
+redisClient.connect();
+
+const redisMatchingAdapter = createRedisMatchingAdapter(redisClient);
+const redisAuthAdapter = createRedisAuthAdapter(redisClient);
 
 const authService: IAuthenticationAgent = createAuthenticationService(
   envConfig.JWT_SIGNING_SECRET,
+  redisAuthAdapter,
 );
-const redisAdapter = createRedisAdapter(envConfig.REDIS_SERVER_URL);
-redisAdapter.connect();
+
+const apiServer = getApiServer(envConfig.HTTP_PORT, envConfig.GRPC_PORT);
+const expressApp = apiServer.getHttpServer();
 
 expressApp.get('/', (_: Request, resp: Response) => {
   resp.status(200).send('Welcome to Matching Service');
 });
 
-apiServer.registerServiceRoutes(new MatchingServiceApi(authService, redisAdapter));
+apiServer.registerServiceRoutes(new MatchingServiceApi(authService, redisMatchingAdapter));
 apiServer.bind();

--- a/matching-service/src/redis_adapter/redis_auth_adapter.ts
+++ b/matching-service/src/redis_adapter/redis_auth_adapter.ts
@@ -1,0 +1,75 @@
+import { RedisClientType } from 'redis';
+
+interface IRedisAuthAdapter {
+  isTokenBlacklisted(token: string): Promise<boolean>;
+  addTokenBlacklist(token: string): Promise<void>;
+  removeTokenBlacklist(token: string): Promise<void>;
+}
+
+const jwtBlacklistKeyspace = 'auth-jwt-blacklist';
+const getBlacklistForDay = (timestamp: string) => `${jwtBlacklistKeyspace}-${timestamp}`;
+const tokenLifespanDays = 3;
+const dayMillis = 24 * 60 * 60 * 1000;
+
+class RedisAuthAdapter implements IRedisAuthAdapter {
+  client: RedisClientType;
+
+  constructor(client: RedisClientType) {
+    this.client = client;
+  }
+
+  async isTokenBlacklisted(token: string): Promise<boolean> {
+    const resultQueries = [];
+    const today = new Date();
+
+    for (let i = 0; i < tokenLifespanDays + 1; i += 1) {
+      const dateToCheck = new Date(today);
+      dateToCheck.setDate(dateToCheck.getDate() - i);
+      const check = this.client.sIsMember(getBlacklistForDay(dateToCheck.toDateString()), token);
+      resultQueries.push(check);
+    }
+
+    const results = await Promise.all(resultQueries);
+    for (let i = 0; i < tokenLifespanDays + 1; i += 1) {
+      if (results[i]) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  async addTokenBlacklist(token: string): Promise<void> {
+    const today = new Date();
+    const dateKey = getBlacklistForDay(today.toDateString());
+    this.client.sAdd(dateKey, token);
+    const todayMillis = today.getTime();
+    const tokenLifespanMillis = (tokenLifespanDays + 1) * dayMillis;
+    const expiryMillis = todayMillis - (todayMillis % dayMillis) + tokenLifespanMillis;
+    this.client.expireAt(
+      dateKey,
+      Math.floor(expiryMillis / 1000),
+    );
+  }
+
+  async removeTokenBlacklist(token: string): Promise<void> {
+    const today = new Date();
+    const operations = [];
+
+    for (let i = 0; i < tokenLifespanDays + 1; i += 1) {
+      const dateToCheck = new Date(today);
+      dateToCheck.setDate(dateToCheck.getDate() - i);
+      operations.push(this.client.sRem(getBlacklistForDay(dateToCheck.toDateString()), token));
+    }
+    await Promise.all(operations);
+  }
+}
+
+function createRedisAuthAdapter(client: RedisClientType): IRedisAuthAdapter {
+  return new RedisAuthAdapter(client);
+}
+
+export {
+  createRedisAuthAdapter,
+  IRedisAuthAdapter,
+};


### PR DESCRIPTION
## Changes
This PR updates the authentication agent on matching service to lookup the Redis blacklist for blacklisted tokens. It is a copy of the authentication agent previously seen in user service.

## Related Issues
- closes #51 