### PR TITLE
Prefix API routes with api

### DIFF
--- a/frontend/src/components/form/TempQueueForm.tsx
+++ b/frontend/src/components/form/TempQueueForm.tsx
@@ -45,7 +45,7 @@ function TempQueueForm() {
       console.error("No difficulty selected");
     }
     axios
-      .post<JoinQueueResponse>("/queue/join", joinQueueReq, {
+      .post<JoinQueueResponse>("/api/queue/join", joinQueueReq, {
         withCredentials: true,
       })
       .then((res) => {

--- a/frontend/src/components/matching/Countdown.tsx
+++ b/frontend/src/components/matching/Countdown.tsx
@@ -39,7 +39,7 @@ function Countdown() {
 
     console.log(`API update call made`);
     axios
-      .post<CheckQueueStatusResponse>("/queue/status", {}, {
+      .post<CheckQueueStatusResponse>("/api/queue/status", {}, {
         withCredentials: true,
       })
       .then((res) => {

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -44,7 +44,7 @@ function Login() {
     const loginReq: LoginRequest = { credentials };
 
     axios
-      .post<LoginResponse>("/user/login", loginReq, {
+      .post<LoginResponse>("/api/user/login", loginReq, {
         withCredentials: true
       })
       .then((res) => {

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -48,7 +48,7 @@ function Register() {
 
     // Send registration request to the server
     axios
-      .post<RegisterResponse>("/user/register", registerRequest)
+      .post<RegisterResponse>("/api/user/register", registerRequest)
       .then((res) => {
         const { data: resData } = res;
 

--- a/frontend/src/pages/Session.tsx
+++ b/frontend/src/pages/Session.tsx
@@ -32,7 +32,7 @@ function Session() {
   const dispatch = useDispatch();
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { sendMessage, lastMessage, readyState } = useWebSocket(
-    "ws://localhost:5001/ws"
+    "ws://localhost:5001/api/roomws"
   );
   // This is a temporary state variable to track the websocket communication
   const [inputVal, setInputVal] = useState("");

--- a/gateway/service_definitions.yaml
+++ b/gateway/service_definitions.yaml
@@ -4,26 +4,26 @@ config_version: 3
 http:
   rules:
     - selector: user_bff_service.UserBFFService.Login
-      post: /user/login
+      post: /api/user/login
       body: "*"
 
     - selector: user_bff_service.UserBFFService.Register
-      post: /user/register
+      post: /api/user/register
       body: "*"
 
     - selector: user_bff_service.UserBFFService.Logout
-      post: /user/logout
+      post: /api/user/logout
       body: "*"
 
     - selector: user_bff_service.UserBFFService.GetUserProfile
-      post: /user/profile
+      post: /api/user/profile
       body: "*"
 
     - selector: matching_service.QueueService.JoinQueue
-      post: /queue/join
+      post: /api/queue/join
       body: "*"
 
     - selector: matching_service.QueueService.CheckQueueStatus
-      post: /queue/status
+      post: /api/queue/status
       body: "*"
     

--- a/gateway/src/auth/auth_mux.go
+++ b/gateway/src/auth/auth_mux.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	loginRoute    = "/user/login"
-	registerRoute = "/user/register"
+	loginRoute    = "/api/user/login"
+	registerRoute = "/api/user/register"
 )
 
 func AttachAuthMiddleware(sessionServiceUrl string, mux http.Handler) (http.Handler, util.Disposable, error) {

--- a/gateway/src/main.go
+++ b/gateway/src/main.go
@@ -41,14 +41,15 @@ func run(config *GatewayConfiguration) error {
 	}
 	defer disposeAuth.Dispose()
 
-	staticMux := AttachStaticServe(config, authMux)
+	staticMux := AttachStaticServe(config.StaticServer)
+	prefixRouter := AttachPrefixRouter("/api", authMux, staticMux)
 
 	corsObj := cors.New(cors.Options{
 		AllowedOrigins:   []string{"http://localhost:*", "http://127.0.0.1:*"},
 		AllowCredentials: true,
 	})
 
-	corsMux := corsObj.Handler(staticMux)
+	corsMux := corsObj.Handler(prefixRouter)
 
 	// Start HTTP server (and proxy calls to gRPC server endpoint)
 	return http.ListenAndServe(":5000", corsMux)

--- a/gateway/src/middleware_prefix_router.go
+++ b/gateway/src/middleware_prefix_router.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+)
+
+func AttachPrefixRouter(prefix string, matchedMux http.Handler, otherwiseMux http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.EscapedPath()
+		if strings.HasPrefix(path, prefix) {
+			matchedMux.ServeHTTP(w, r)
+			return
+		}
+		otherwiseMux.ServeHTTP(w, r)
+	})
+}

--- a/gateway/src/middleware_proxy.go
+++ b/gateway/src/middleware_proxy.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 )
 
-const websocketRoute = "/ws"
+const websocketRoute = "/api/roomws"
 
 func AttachProxyMiddleware(config *GatewayConfiguration, mux http.Handler) (http.Handler, error) {
 	proxyManager := proxy.CreateWebsocketProxyManager()

--- a/gateway/src/middleware_static.go
+++ b/gateway/src/middleware_static.go
@@ -4,31 +4,27 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"strings"
 )
 
-func AttachStaticServe(config *GatewayConfiguration, mux http.Handler) http.Handler {
+func AttachStaticServe(server string) http.Handler {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.EscapedPath()
-		if path == "/" || strings.HasPrefix(path, "/static") {
-			resp, err := http.Get(fmt.Sprintf("http://%s%s", config.StaticServer, path))
-			if err != nil {
-				w.WriteHeader(404)
-				return
-			}
-
-			data, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				w.WriteHeader(404)
-				return
-			}
-
-			w.Header().Set("Content-Type", resp.Header.Get("Content-Type"))
-			w.WriteHeader(resp.StatusCode)
-			w.Write(data)
+		resp, err := http.Get(fmt.Sprintf("http://%s%s", server, path))
+		if err != nil {
+			w.WriteHeader(404)
 			return
 		}
-		mux.ServeHTTP(w, r)
+
+		data, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			w.WriteHeader(404)
+			return
+		}
+
+		w.Header().Set("Content-Type", resp.Header.Get("Content-Type"))
+		w.WriteHeader(resp.StatusCode)
+		w.Write(data)
+		return
 	})
 	return handler
 }

--- a/gateway/src/proto/matching-service.pb.gw.go
+++ b/gateway/src/proto/matching-service.pb.gw.go
@@ -113,7 +113,7 @@ func RegisterQueueServiceHandlerServer(ctx context.Context, mux *runtime.ServeMu
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
 		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/matching_service.QueueService/JoinQueue", runtime.WithHTTPPathPattern("/queue/join"))
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/matching_service.QueueService/JoinQueue", runtime.WithHTTPPathPattern("/api/queue/join"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -138,7 +138,7 @@ func RegisterQueueServiceHandlerServer(ctx context.Context, mux *runtime.ServeMu
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
 		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/matching_service.QueueService/CheckQueueStatus", runtime.WithHTTPPathPattern("/queue/status"))
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/matching_service.QueueService/CheckQueueStatus", runtime.WithHTTPPathPattern("/api/queue/status"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -202,7 +202,7 @@ func RegisterQueueServiceHandlerClient(ctx context.Context, mux *runtime.ServeMu
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
 		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/matching_service.QueueService/JoinQueue", runtime.WithHTTPPathPattern("/queue/join"))
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/matching_service.QueueService/JoinQueue", runtime.WithHTTPPathPattern("/api/queue/join"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -224,7 +224,7 @@ func RegisterQueueServiceHandlerClient(ctx context.Context, mux *runtime.ServeMu
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
 		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/matching_service.QueueService/CheckQueueStatus", runtime.WithHTTPPathPattern("/queue/status"))
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/matching_service.QueueService/CheckQueueStatus", runtime.WithHTTPPathPattern("/api/queue/status"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -244,9 +244,9 @@ func RegisterQueueServiceHandlerClient(ctx context.Context, mux *runtime.ServeMu
 }
 
 var (
-	pattern_QueueService_JoinQueue_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"queue", "join"}, ""))
+	pattern_QueueService_JoinQueue_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "queue", "join"}, ""))
 
-	pattern_QueueService_CheckQueueStatus_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"queue", "status"}, ""))
+	pattern_QueueService_CheckQueueStatus_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "queue", "status"}, ""))
 )
 
 var (

--- a/gateway/src/proto/user-bff-service.pb.gw.go
+++ b/gateway/src/proto/user-bff-service.pb.gw.go
@@ -181,7 +181,7 @@ func RegisterUserBFFServiceHandlerServer(ctx context.Context, mux *runtime.Serve
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
 		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/user_bff_service.UserBFFService/Login", runtime.WithHTTPPathPattern("/user/login"))
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/user_bff_service.UserBFFService/Login", runtime.WithHTTPPathPattern("/api/user/login"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -206,7 +206,7 @@ func RegisterUserBFFServiceHandlerServer(ctx context.Context, mux *runtime.Serve
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
 		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/user_bff_service.UserBFFService/Register", runtime.WithHTTPPathPattern("/user/register"))
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/user_bff_service.UserBFFService/Register", runtime.WithHTTPPathPattern("/api/user/register"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -231,7 +231,7 @@ func RegisterUserBFFServiceHandlerServer(ctx context.Context, mux *runtime.Serve
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
 		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/user_bff_service.UserBFFService/Logout", runtime.WithHTTPPathPattern("/user/logout"))
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/user_bff_service.UserBFFService/Logout", runtime.WithHTTPPathPattern("/api/user/logout"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -256,7 +256,7 @@ func RegisterUserBFFServiceHandlerServer(ctx context.Context, mux *runtime.Serve
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
 		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/user_bff_service.UserBFFService/GetUserProfile", runtime.WithHTTPPathPattern("/user/profile"))
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/user_bff_service.UserBFFService/GetUserProfile", runtime.WithHTTPPathPattern("/api/user/profile"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -320,7 +320,7 @@ func RegisterUserBFFServiceHandlerClient(ctx context.Context, mux *runtime.Serve
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
 		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/user_bff_service.UserBFFService/Login", runtime.WithHTTPPathPattern("/user/login"))
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/user_bff_service.UserBFFService/Login", runtime.WithHTTPPathPattern("/api/user/login"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -342,7 +342,7 @@ func RegisterUserBFFServiceHandlerClient(ctx context.Context, mux *runtime.Serve
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
 		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/user_bff_service.UserBFFService/Register", runtime.WithHTTPPathPattern("/user/register"))
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/user_bff_service.UserBFFService/Register", runtime.WithHTTPPathPattern("/api/user/register"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -364,7 +364,7 @@ func RegisterUserBFFServiceHandlerClient(ctx context.Context, mux *runtime.Serve
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
 		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/user_bff_service.UserBFFService/Logout", runtime.WithHTTPPathPattern("/user/logout"))
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/user_bff_service.UserBFFService/Logout", runtime.WithHTTPPathPattern("/api/user/logout"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -386,7 +386,7 @@ func RegisterUserBFFServiceHandlerClient(ctx context.Context, mux *runtime.Serve
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
 		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/user_bff_service.UserBFFService/GetUserProfile", runtime.WithHTTPPathPattern("/user/profile"))
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/user_bff_service.UserBFFService/GetUserProfile", runtime.WithHTTPPathPattern("/api/user/profile"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -406,13 +406,13 @@ func RegisterUserBFFServiceHandlerClient(ctx context.Context, mux *runtime.Serve
 }
 
 var (
-	pattern_UserBFFService_Login_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"user", "login"}, ""))
+	pattern_UserBFFService_Login_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "user", "login"}, ""))
 
-	pattern_UserBFFService_Register_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"user", "register"}, ""))
+	pattern_UserBFFService_Register_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "user", "register"}, ""))
 
-	pattern_UserBFFService_Logout_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"user", "logout"}, ""))
+	pattern_UserBFFService_Logout_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "user", "logout"}, ""))
 
-	pattern_UserBFFService_GetUserProfile_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"user", "profile"}, ""))
+	pattern_UserBFFService_GetUserProfile_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "user", "profile"}, ""))
 )
 
 var (


### PR DESCRIPTION
## Changes
This PR is a hotfix that prefixes all API routes with `/api`