### PR TITLE
[CollaborationUI] Change Language with Syntax Highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,7 @@ PeerPrep is a web application for collaborating on technical interview questions
 2. Then, run `npm run-script sync-schema`.
 
 ## Frontend
-1. Install npm packages using `npm i`.
-2. Run Frontend using `npm start`.
+1. In the root of the project, run `npm run-script gen-y-websocket`.
+2. Go the the frontend using `cd frontend/`.
+3. Install npm packages using `npm i`.
+4. Run Frontend using `npm start`.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19513,7 +19513,7 @@
     "node_modules/y-websocket-peerprep": {
       "version": "1.4.5",
       "resolved": "file:y-websocket-peerprep-1.4.5.tgz",
-      "integrity": "sha512-B7Gbcp+WSVgJOiTqI99DP08EDas77XCw9U/GgwGTw21dHTfQfmJTKj3rTR1NAFPogEP4/jpdiJdKALybTSGtAg==",
+      "integrity": "sha512-yJqfeebBK2/oITtDflwk5rQ/RqWlxHz0cHNY0hpSqCyHPX+yPy1wKYDCvSHaxvbVLtSYc5yJ7TFF7ERw/Gw6ZA==",
       "license": "MIT",
       "dependencies": {
         "lib0": "^0.2.52",
@@ -19533,7 +19533,7 @@
         "y-leveldb": "^0.1.0"
       },
       "peerDependencies": {
-        "yjs": "^13.5.6"
+        "yjs": "13.5.41"
       }
     },
     "node_modules/y-websocket-peerprep/node_modules/ws": {
@@ -33549,7 +33549,7 @@
     },
     "y-websocket-peerprep": {
       "version": "file:y-websocket-peerprep-1.4.5.tgz",
-      "integrity": "sha512-B7Gbcp+WSVgJOiTqI99DP08EDas77XCw9U/GgwGTw21dHTfQfmJTKj3rTR1NAFPogEP4/jpdiJdKALybTSGtAg==",
+      "integrity": "sha512-yJqfeebBK2/oITtDflwk5rQ/RqWlxHz0cHNY0hpSqCyHPX+yPy1wKYDCvSHaxvbVLtSYc5yJ7TFF7ERw/Gw6ZA==",
       "requires": {
         "lib0": "^0.2.52",
         "lodash.debounce": "^4.0.8",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,10 @@
       "dependencies": {
         "@chakra-ui/icons": "^2.0.9",
         "@chakra-ui/react": "^2.2.9",
+        "@codemirror/lang-java": "^6.0.0",
         "@codemirror/lang-javascript": "^6.0.2",
+        "@codemirror/lang-python": "^6.0.2",
+        "@codemirror/language": "^6.2.1",
         "@emotion/react": "^11.10.0",
         "@emotion/styled": "^11.10.0",
         "@grpc/grpc-js": "^1.6.12",
@@ -22,6 +25,7 @@
         "@types/node": "^12.20.55",
         "@types/react": "^18.0.17",
         "@types/react-dom": "^18.0.6",
+        "@uiw/codemirror-extensions-langs": "^4.12.3",
         "@uiw/react-codemirror": "^4.12.3",
         "axios": "^0.27.2",
         "framer-motion": "^6.5.1",
@@ -3009,6 +3013,50 @@
         "@lezer/common": "^1.0.0"
       }
     },
+    "node_modules/@codemirror/lang-cpp": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-cpp/-/lang-cpp-6.0.1.tgz",
+      "integrity": "sha512-46p3ohfhjzkLWJ3VwvzX0aqlXh8UkEqX1xo2Eds9l6Ql3uDoxI2IZEjR9cgJaGOZTXCkDzQuQH7sfYAxMvzLjA==",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/cpp": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-css": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.0.0.tgz",
+      "integrity": "sha512-jBqc+BTuwhNOTlrimFghLlSrN6iFuE44HULKWoR4qKYObhOIl9Lci1iYj6zMIte1XTQmZguNvjXMyr43LUKwSw==",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/css": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-html": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.1.2.tgz",
+      "integrity": "sha512-e8JAUWyOo7N26tmek+WK0+Zg+pZRe+dQi8TZq0OOVVygpLV+mNAT2n5b5JhknY+TVZIVGLjuhdsoizw1SDFfPg==",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.2.2",
+        "@lezer/common": "^1.0.0",
+        "@lezer/html": "^1.0.1"
+      }
+    },
+    "node_modules/@codemirror/lang-java": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-java/-/lang-java-6.0.0.tgz",
+      "integrity": "sha512-aeWq+ikUS6Eubk6RBbiMgxuBIT4Ih8Asb1qc2pSiMcstrwr4ODbazPXsBHbLBYg3aObvFyOm2bNQncbQJjZ3sQ==",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/java": "^1.0.0"
+      }
+    },
     "node_modules/@codemirror/lang-javascript": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.0.2.tgz",
@@ -3023,6 +3071,103 @@
         "@lezer/javascript": "^1.0.0"
       }
     },
+    "node_modules/@codemirror/lang-json": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.0.tgz",
+      "integrity": "sha512-DvTcYTKLmg2viADXlTdufrT334M9jowe1qO02W28nvm+nejcvhM5vot5mE8/kPrxYw/HJHhwu1z2PyBpnMLCNQ==",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/json": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-lezer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-lezer/-/lang-lezer-6.0.0.tgz",
+      "integrity": "sha512-ZZMAVo/P5Qk2iUdylUJk6afDjOMpwNlm5x4KAbH2v0jlMyMG8LclTvNiQa/d6rw81cNXz4zYoXea1V+mdNu9Zw==",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/lezer": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-markdown": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.0.1.tgz",
+      "integrity": "sha512-pHPQuRwf9cUrmkmsTHRjtS9ZnGu3fA9YzAdh2++d+L9wbfnC2XbKh0Xvm/0YiUjdCnoCx9wDFEoCuAnkqKWLIw==",
+      "dependencies": {
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/markdown": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-php": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-php/-/lang-php-6.0.0.tgz",
+      "integrity": "sha512-96CEjq0xEgbzc6bdFPwILPfZ6m8917JRbh2oPszZJABlYxG4Y+eYjtYkUTDb4yuyjQKyigHoeGC6zoIOYA1NWA==",
+      "dependencies": {
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/php": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-python": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-6.0.2.tgz",
+      "integrity": "sha512-5BidNrfhab3s9LYNSN7JWFjL1+1zGAIw0dxUyalNwsUN+uCVE62sTk3uJlMZux4SsyT6fR8LbOLtWu52XQL6Yw==",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/python": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-rust": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-rust/-/lang-rust-6.0.0.tgz",
+      "integrity": "sha512-VQql3Qk1BwoXb3SUkeWll/EEwhsgQWc1bpia7CFqqp2PhQBb5A6r4Vj2JCkU/nE6A7TDPSGHTOoqJSG5s/VXtQ==",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/rust": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-sql": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-sql/-/lang-sql-6.3.0.tgz",
+      "integrity": "sha512-+4vyqZMmvseeORW44RMYF3rDGhQG9f7GOXZitrIqSrUHI33DgIudK2qTcaf9TfCuJdOxPEp4xEGvm0H+FBAhVw==",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-wast": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-wast/-/lang-wast-6.0.0.tgz",
+      "integrity": "sha512-vSbtLrxuB95PC5LJ+yszKVmBUkLmMdowNFjjn0e+LHeBzvpdQJHVomgE76UUFeZGW+Ht0VfM6rxEd9SL85FuhA==",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-xml": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-xml/-/lang-xml-6.0.0.tgz",
+      "integrity": "sha512-M/HLWxIiP956xGjtrxkeHkCmDGVQGKu782x8pOH5CLJIMkWtiB1DWfDoDHqpFjdEE9dkfcqPWvYfVi6GbhuXEg==",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/xml": "^1.0.0"
+      }
+    },
     "node_modules/@codemirror/language": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.2.1.tgz",
@@ -3034,6 +3179,36 @@
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.0.0",
         "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/language-data": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/language-data/-/language-data-6.1.0.tgz",
+      "integrity": "sha512-g9V23fuLRI9AEbpM6bDy1oquqgpFlIDHTihUhL21NPmxp+x67ZJbsKk+V71W7/Bj8SCqEO1PtqQA/tDGgt1nfw==",
+      "dependencies": {
+        "@codemirror/lang-cpp": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/lang-java": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/lang-json": "^6.0.0",
+        "@codemirror/lang-markdown": "^6.0.0",
+        "@codemirror/lang-php": "^6.0.0",
+        "@codemirror/lang-python": "^6.0.0",
+        "@codemirror/lang-rust": "^6.0.0",
+        "@codemirror/lang-sql": "^6.0.0",
+        "@codemirror/lang-wast": "^6.0.0",
+        "@codemirror/lang-xml": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/legacy-modes": "^6.1.0"
+      }
+    },
+    "node_modules/@codemirror/legacy-modes": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-6.1.0.tgz",
+      "integrity": "sha512-V/PgGpndkZeTn3Hdlg/gd8MLFdyvTCIX+iwJzjUw5iNziWiNsAY8X0jvf7m3gSfxnKkNzmid6l0g4rYSpiDaCw==",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0"
       }
     },
     "node_modules/@codemirror/lint": {
@@ -4395,12 +4570,49 @@
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.0.1.tgz",
       "integrity": "sha512-8TR5++Q/F//tpDsLd5zkrvEX5xxeemafEaek7mUp7Y+bI8cKQXdSqhzTOBaOogETcMOVr0pT3BBPXp13477ciw=="
     },
+    "node_modules/@lezer/cpp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lezer/cpp/-/cpp-1.0.0.tgz",
+      "integrity": "sha512-Klk3/AIEKoptmm6cNm7xTulNXjdTKkD+hVOEcz/NeRg8tIestP5hsGHJeFDR/XtyDTxsjoPjKZRIGohht7zbKw==",
+      "dependencies": {
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/css": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.0.0.tgz",
+      "integrity": "sha512-616VqgDKumHmYIuxs3tnX1irEQmoDHgF/TlP4O5ICWwyHwLMErq+8iKVuzTkOdBqvYAVmObqThcDEAaaMJjAdg==",
+      "dependencies": {
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
     "node_modules/@lezer/highlight": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.0.0.tgz",
       "integrity": "sha512-nsCnNtim90UKsB5YxoX65v3GEIw3iCHw9RM2DtdgkiqAbKh9pCdvi8AWNwkYf10Lu6fxNhXPpkpHbW6mihhvJA==",
       "dependencies": {
         "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/html": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.0.1.tgz",
+      "integrity": "sha512-sC00zEt3GBh3vVO6QaGX4YZCl41S9dHWN/WGBsDixy9G+sqOC7gsa4cxA/fmRVAiBvhqYkJk+5Ul4oul92CPVw==",
+      "dependencies": {
+        "@lezer/common": "^1.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/java": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lezer/java/-/java-1.0.0.tgz",
+      "integrity": "sha512-z2EA0JHq2WoiKfQy5uOOd4t17PJtq8guh58gPkSzOnNcQ7DNbkrU+Axak+jL8+Noinwyz2tRNOseQFj+Tg+P0A==",
+      "dependencies": {
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
       }
     },
     "node_modules/@lezer/javascript": {
@@ -4412,12 +4624,75 @@
         "@lezer/lr": "^1.0.0"
       }
     },
+    "node_modules/@lezer/json": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.0.tgz",
+      "integrity": "sha512-zbAuUY09RBzCoCA3lJ1+ypKw5WSNvLqGMtasdW6HvVOqZoCpPr8eWrsGnOVWGKGn8Rh21FnrKRVlJXrGAVUqRw==",
+      "dependencies": {
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/lezer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lezer/lezer/-/lezer-1.1.0.tgz",
+      "integrity": "sha512-XTomM3C2MzHNuZwjYbyYZ44IRV6rHIOvi++yAD1O4djlDoKAnikx3BFoREK2g/z8zUIc/kyWuZO9W9xN4/OR1g==",
+      "dependencies": {
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
     "node_modules/@lezer/lr": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.2.3.tgz",
       "integrity": "sha512-qpB7rBzH8f6Mzjv2AVZRahcm+2Cf7nbIH++uXbvVOL1yIRvVWQ3HAM/saeBLCyz/togB7LGo76qdJYL1uKQlqA==",
       "dependencies": {
         "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/markdown": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.0.2.tgz",
+      "integrity": "sha512-8CY0OoZ6V5EzPjSPeJ4KLVbtXdLBd8V6sRCooN5kHnO28ytreEGTyrtU/zUwo/XLRzGr/e1g44KlzKi3yWGB5A==",
+      "dependencies": {
+        "@lezer/common": "^1.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/php": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lezer/php/-/php-1.0.0.tgz",
+      "integrity": "sha512-kFQu/mk/vmjpA+fjQU87d9eimqKJ9PFCa8CZCPFWGEwNnm7Ahpw32N+HYEU/YAQ0XcfmOAnW/YJCEa8WpUOMMw==",
+      "dependencies": {
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/python": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lezer/python/-/python-1.1.0.tgz",
+      "integrity": "sha512-FVPp2usfj3zZuc+2RidXAY94WAcsHQ3dbKDbXuZgoAwUungAcXwd3EWXiWQvwNqbae+ek51bWi8dwbiQqweWCg==",
+      "dependencies": {
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/rust": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lezer/rust/-/rust-1.0.0.tgz",
+      "integrity": "sha512-IpGAxIjNxYmX9ra6GfQTSPegdCAWNeq23WNmrsMMQI7YNSvKtYxO4TX5rgZUmbhEucWn0KTBMeDEPXg99YKtTA==",
+      "dependencies": {
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/xml": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lezer/xml/-/xml-1.0.0.tgz",
+      "integrity": "sha512-73iI9UK8iqSvWtLlOEl/g+50ivwQn8Ge6foHVN66AXUS1RccFnAoc7BYU8b3c8/rP6dfCOGqAGaWLxBzhj60MA==",
+      "dependencies": {
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
       }
     },
     "node_modules/@motionone/animation": {
@@ -6005,6 +6280,32 @@
         "@codemirror/search": ">=6.0.0",
         "@codemirror/state": ">=6.0.0",
         "@codemirror/view": ">=6.0.0"
+      }
+    },
+    "node_modules/@uiw/codemirror-extensions-langs": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-langs/-/codemirror-extensions-langs-4.12.3.tgz",
+      "integrity": "sha512-Er9WSDto5slQWcUnNBZnPg+z9fUS2tx+ZuAzdL9CUtc3vGkCLDyq2UvpVr27H88DM20zslzxhRtQB7W5mobubQ==",
+      "dependencies": {
+        "@codemirror/lang-cpp": "~6.0.0",
+        "@codemirror/lang-html": "~6.1.0",
+        "@codemirror/lang-java": "~6.0.0",
+        "@codemirror/lang-javascript": "~6.0.0",
+        "@codemirror/lang-json": "~6.0.0",
+        "@codemirror/lang-lezer": "~6.0.0",
+        "@codemirror/lang-markdown": "~6.0.0",
+        "@codemirror/lang-php": "~6.0.0",
+        "@codemirror/lang-python": "~6.0.0",
+        "@codemirror/lang-rust": "~6.0.0",
+        "@codemirror/lang-sql": "~6.3.0",
+        "@codemirror/lang-wast": "^6.0.0",
+        "@codemirror/lang-xml": "~6.0.0",
+        "@codemirror/language-data": ">=6.0.0",
+        "@codemirror/legacy-modes": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "@codemirror/language-data": ">=6.0.0",
+        "@codemirror/legacy-modes": ">=6.0.0"
       }
     },
     "node_modules/@uiw/react-codemirror": {
@@ -21694,6 +21995,50 @@
         "@lezer/common": "^1.0.0"
       }
     },
+    "@codemirror/lang-cpp": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-cpp/-/lang-cpp-6.0.1.tgz",
+      "integrity": "sha512-46p3ohfhjzkLWJ3VwvzX0aqlXh8UkEqX1xo2Eds9l6Ql3uDoxI2IZEjR9cgJaGOZTXCkDzQuQH7sfYAxMvzLjA==",
+      "requires": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/cpp": "^1.0.0"
+      }
+    },
+    "@codemirror/lang-css": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.0.0.tgz",
+      "integrity": "sha512-jBqc+BTuwhNOTlrimFghLlSrN6iFuE44HULKWoR4qKYObhOIl9Lci1iYj6zMIte1XTQmZguNvjXMyr43LUKwSw==",
+      "requires": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/css": "^1.0.0"
+      }
+    },
+    "@codemirror/lang-html": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.1.2.tgz",
+      "integrity": "sha512-e8JAUWyOo7N26tmek+WK0+Zg+pZRe+dQi8TZq0OOVVygpLV+mNAT2n5b5JhknY+TVZIVGLjuhdsoizw1SDFfPg==",
+      "requires": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.2.2",
+        "@lezer/common": "^1.0.0",
+        "@lezer/html": "^1.0.1"
+      }
+    },
+    "@codemirror/lang-java": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-java/-/lang-java-6.0.0.tgz",
+      "integrity": "sha512-aeWq+ikUS6Eubk6RBbiMgxuBIT4Ih8Asb1qc2pSiMcstrwr4ODbazPXsBHbLBYg3aObvFyOm2bNQncbQJjZ3sQ==",
+      "requires": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/java": "^1.0.0"
+      }
+    },
     "@codemirror/lang-javascript": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.0.2.tgz",
@@ -21708,6 +22053,103 @@
         "@lezer/javascript": "^1.0.0"
       }
     },
+    "@codemirror/lang-json": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.0.tgz",
+      "integrity": "sha512-DvTcYTKLmg2viADXlTdufrT334M9jowe1qO02W28nvm+nejcvhM5vot5mE8/kPrxYw/HJHhwu1z2PyBpnMLCNQ==",
+      "requires": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/json": "^1.0.0"
+      }
+    },
+    "@codemirror/lang-lezer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-lezer/-/lang-lezer-6.0.0.tgz",
+      "integrity": "sha512-ZZMAVo/P5Qk2iUdylUJk6afDjOMpwNlm5x4KAbH2v0jlMyMG8LclTvNiQa/d6rw81cNXz4zYoXea1V+mdNu9Zw==",
+      "requires": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/lezer": "^1.0.0"
+      }
+    },
+    "@codemirror/lang-markdown": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.0.1.tgz",
+      "integrity": "sha512-pHPQuRwf9cUrmkmsTHRjtS9ZnGu3fA9YzAdh2++d+L9wbfnC2XbKh0Xvm/0YiUjdCnoCx9wDFEoCuAnkqKWLIw==",
+      "requires": {
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/markdown": "^1.0.0"
+      }
+    },
+    "@codemirror/lang-php": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-php/-/lang-php-6.0.0.tgz",
+      "integrity": "sha512-96CEjq0xEgbzc6bdFPwILPfZ6m8917JRbh2oPszZJABlYxG4Y+eYjtYkUTDb4yuyjQKyigHoeGC6zoIOYA1NWA==",
+      "requires": {
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/php": "^1.0.0"
+      }
+    },
+    "@codemirror/lang-python": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-6.0.2.tgz",
+      "integrity": "sha512-5BidNrfhab3s9LYNSN7JWFjL1+1zGAIw0dxUyalNwsUN+uCVE62sTk3uJlMZux4SsyT6fR8LbOLtWu52XQL6Yw==",
+      "requires": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/python": "^1.0.0"
+      }
+    },
+    "@codemirror/lang-rust": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-rust/-/lang-rust-6.0.0.tgz",
+      "integrity": "sha512-VQql3Qk1BwoXb3SUkeWll/EEwhsgQWc1bpia7CFqqp2PhQBb5A6r4Vj2JCkU/nE6A7TDPSGHTOoqJSG5s/VXtQ==",
+      "requires": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/rust": "^1.0.0"
+      }
+    },
+    "@codemirror/lang-sql": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-sql/-/lang-sql-6.3.0.tgz",
+      "integrity": "sha512-+4vyqZMmvseeORW44RMYF3rDGhQG9f7GOXZitrIqSrUHI33DgIudK2qTcaf9TfCuJdOxPEp4xEGvm0H+FBAhVw==",
+      "requires": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "@codemirror/lang-wast": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-wast/-/lang-wast-6.0.0.tgz",
+      "integrity": "sha512-vSbtLrxuB95PC5LJ+yszKVmBUkLmMdowNFjjn0e+LHeBzvpdQJHVomgE76UUFeZGW+Ht0VfM6rxEd9SL85FuhA==",
+      "requires": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "@codemirror/lang-xml": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-xml/-/lang-xml-6.0.0.tgz",
+      "integrity": "sha512-M/HLWxIiP956xGjtrxkeHkCmDGVQGKu782x8pOH5CLJIMkWtiB1DWfDoDHqpFjdEE9dkfcqPWvYfVi6GbhuXEg==",
+      "requires": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/xml": "^1.0.0"
+      }
+    },
     "@codemirror/language": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.2.1.tgz",
@@ -21719,6 +22161,36 @@
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.0.0",
         "style-mod": "^4.0.0"
+      }
+    },
+    "@codemirror/language-data": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/language-data/-/language-data-6.1.0.tgz",
+      "integrity": "sha512-g9V23fuLRI9AEbpM6bDy1oquqgpFlIDHTihUhL21NPmxp+x67ZJbsKk+V71W7/Bj8SCqEO1PtqQA/tDGgt1nfw==",
+      "requires": {
+        "@codemirror/lang-cpp": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/lang-java": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/lang-json": "^6.0.0",
+        "@codemirror/lang-markdown": "^6.0.0",
+        "@codemirror/lang-php": "^6.0.0",
+        "@codemirror/lang-python": "^6.0.0",
+        "@codemirror/lang-rust": "^6.0.0",
+        "@codemirror/lang-sql": "^6.0.0",
+        "@codemirror/lang-wast": "^6.0.0",
+        "@codemirror/lang-xml": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/legacy-modes": "^6.1.0"
+      }
+    },
+    "@codemirror/legacy-modes": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-6.1.0.tgz",
+      "integrity": "sha512-V/PgGpndkZeTn3Hdlg/gd8MLFdyvTCIX+iwJzjUw5iNziWiNsAY8X0jvf7m3gSfxnKkNzmid6l0g4rYSpiDaCw==",
+      "requires": {
+        "@codemirror/language": "^6.0.0"
       }
     },
     "@codemirror/lint": {
@@ -22668,12 +23140,49 @@
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.0.1.tgz",
       "integrity": "sha512-8TR5++Q/F//tpDsLd5zkrvEX5xxeemafEaek7mUp7Y+bI8cKQXdSqhzTOBaOogETcMOVr0pT3BBPXp13477ciw=="
     },
+    "@lezer/cpp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lezer/cpp/-/cpp-1.0.0.tgz",
+      "integrity": "sha512-Klk3/AIEKoptmm6cNm7xTulNXjdTKkD+hVOEcz/NeRg8tIestP5hsGHJeFDR/XtyDTxsjoPjKZRIGohht7zbKw==",
+      "requires": {
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "@lezer/css": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.0.0.tgz",
+      "integrity": "sha512-616VqgDKumHmYIuxs3tnX1irEQmoDHgF/TlP4O5ICWwyHwLMErq+8iKVuzTkOdBqvYAVmObqThcDEAaaMJjAdg==",
+      "requires": {
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
     "@lezer/highlight": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.0.0.tgz",
       "integrity": "sha512-nsCnNtim90UKsB5YxoX65v3GEIw3iCHw9RM2DtdgkiqAbKh9pCdvi8AWNwkYf10Lu6fxNhXPpkpHbW6mihhvJA==",
       "requires": {
         "@lezer/common": "^1.0.0"
+      }
+    },
+    "@lezer/html": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.0.1.tgz",
+      "integrity": "sha512-sC00zEt3GBh3vVO6QaGX4YZCl41S9dHWN/WGBsDixy9G+sqOC7gsa4cxA/fmRVAiBvhqYkJk+5Ul4oul92CPVw==",
+      "requires": {
+        "@lezer/common": "^1.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "@lezer/java": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lezer/java/-/java-1.0.0.tgz",
+      "integrity": "sha512-z2EA0JHq2WoiKfQy5uOOd4t17PJtq8guh58gPkSzOnNcQ7DNbkrU+Axak+jL8+Noinwyz2tRNOseQFj+Tg+P0A==",
+      "requires": {
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
       }
     },
     "@lezer/javascript": {
@@ -22685,12 +23194,75 @@
         "@lezer/lr": "^1.0.0"
       }
     },
+    "@lezer/json": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.0.tgz",
+      "integrity": "sha512-zbAuUY09RBzCoCA3lJ1+ypKw5WSNvLqGMtasdW6HvVOqZoCpPr8eWrsGnOVWGKGn8Rh21FnrKRVlJXrGAVUqRw==",
+      "requires": {
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "@lezer/lezer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lezer/lezer/-/lezer-1.1.0.tgz",
+      "integrity": "sha512-XTomM3C2MzHNuZwjYbyYZ44IRV6rHIOvi++yAD1O4djlDoKAnikx3BFoREK2g/z8zUIc/kyWuZO9W9xN4/OR1g==",
+      "requires": {
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
     "@lezer/lr": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.2.3.tgz",
       "integrity": "sha512-qpB7rBzH8f6Mzjv2AVZRahcm+2Cf7nbIH++uXbvVOL1yIRvVWQ3HAM/saeBLCyz/togB7LGo76qdJYL1uKQlqA==",
       "requires": {
         "@lezer/common": "^1.0.0"
+      }
+    },
+    "@lezer/markdown": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.0.2.tgz",
+      "integrity": "sha512-8CY0OoZ6V5EzPjSPeJ4KLVbtXdLBd8V6sRCooN5kHnO28ytreEGTyrtU/zUwo/XLRzGr/e1g44KlzKi3yWGB5A==",
+      "requires": {
+        "@lezer/common": "^1.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "@lezer/php": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lezer/php/-/php-1.0.0.tgz",
+      "integrity": "sha512-kFQu/mk/vmjpA+fjQU87d9eimqKJ9PFCa8CZCPFWGEwNnm7Ahpw32N+HYEU/YAQ0XcfmOAnW/YJCEa8WpUOMMw==",
+      "requires": {
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "@lezer/python": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lezer/python/-/python-1.1.0.tgz",
+      "integrity": "sha512-FVPp2usfj3zZuc+2RidXAY94WAcsHQ3dbKDbXuZgoAwUungAcXwd3EWXiWQvwNqbae+ek51bWi8dwbiQqweWCg==",
+      "requires": {
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "@lezer/rust": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lezer/rust/-/rust-1.0.0.tgz",
+      "integrity": "sha512-IpGAxIjNxYmX9ra6GfQTSPegdCAWNeq23WNmrsMMQI7YNSvKtYxO4TX5rgZUmbhEucWn0KTBMeDEPXg99YKtTA==",
+      "requires": {
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "@lezer/xml": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lezer/xml/-/xml-1.0.0.tgz",
+      "integrity": "sha512-73iI9UK8iqSvWtLlOEl/g+50ivwQn8Ge6foHVN66AXUS1RccFnAoc7BYU8b3c8/rP6dfCOGqAGaWLxBzhj60MA==",
+      "requires": {
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
       }
     },
     "@motionone/animation": {
@@ -23862,6 +24434,28 @@
         "@codemirror/search": "^6.0.0",
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0"
+      }
+    },
+    "@uiw/codemirror-extensions-langs": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-langs/-/codemirror-extensions-langs-4.12.3.tgz",
+      "integrity": "sha512-Er9WSDto5slQWcUnNBZnPg+z9fUS2tx+ZuAzdL9CUtc3vGkCLDyq2UvpVr27H88DM20zslzxhRtQB7W5mobubQ==",
+      "requires": {
+        "@codemirror/lang-cpp": "~6.0.0",
+        "@codemirror/lang-html": "~6.1.0",
+        "@codemirror/lang-java": "~6.0.0",
+        "@codemirror/lang-javascript": "~6.0.0",
+        "@codemirror/lang-json": "~6.0.0",
+        "@codemirror/lang-lezer": "~6.0.0",
+        "@codemirror/lang-markdown": "~6.0.0",
+        "@codemirror/lang-php": "~6.0.0",
+        "@codemirror/lang-python": "~6.0.0",
+        "@codemirror/lang-rust": "~6.0.0",
+        "@codemirror/lang-sql": "~6.3.0",
+        "@codemirror/lang-wast": "^6.0.0",
+        "@codemirror/lang-xml": "~6.0.0",
+        "@codemirror/language-data": ">=6.0.0",
+        "@codemirror/legacy-modes": ">=6.0.0"
       }
     },
     "@uiw/react-codemirror": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,10 @@
   "dependencies": {
     "@chakra-ui/icons": "^2.0.9",
     "@chakra-ui/react": "^2.2.9",
+    "@codemirror/lang-java": "^6.0.0",
     "@codemirror/lang-javascript": "^6.0.2",
+    "@codemirror/lang-python": "^6.0.2",
+    "@codemirror/language": "^6.2.1",
     "@emotion/react": "^11.10.0",
     "@emotion/styled": "^11.10.0",
     "@grpc/grpc-js": "^1.6.12",
@@ -17,6 +20,7 @@
     "@types/node": "^12.20.55",
     "@types/react": "^18.0.17",
     "@types/react-dom": "^18.0.6",
+    "@uiw/codemirror-extensions-langs": "^4.12.3",
     "@uiw/react-codemirror": "^4.12.3",
     "axios": "^0.27.2",
     "framer-motion": "^6.5.1",

--- a/frontend/src/components/editor/Editor.tsx
+++ b/frontend/src/components/editor/Editor.tsx
@@ -1,13 +1,10 @@
 import CodeMirror from "@uiw/react-codemirror";
 import { loadLanguage } from "@uiw/codemirror-extensions-langs";
-// import { javascript } from "@codemirror/lang-javascript";
-// import { java } from "@codemirror/lang-java";
-// import { python } from "@codemirror/lang-python";
-// import { StreamLanguage } from "@codemirror/language";
 import * as Y from "yjs";
 import React, { useEffect } from "react";
 import { WebsocketProvider } from "y-websocket-peerprep";
 import { yCollab } from "y-codemirror.next";
+import { Language } from "../../types";
 
 let providerSet = false;
 
@@ -16,7 +13,7 @@ type Props = {
   provider: WebsocketProvider;
   undoManager: Y.UndoManager;
   nickname: string;
-  selectedLang: "javascript" | "java" | "python" | "go";
+  selectedLang: Language;
 };
 
 function Editor({
@@ -24,14 +21,14 @@ function Editor({
   provider,
   undoManager,
   nickname,
-  selectedLang
+  selectedLang,
 }: Props) {
   useEffect(() => {
     if (!providerSet) {
       provider.awareness.setLocalStateField("user", {
         name: nickname,
         color: "#6eeb83",
-        colorLight: "#6eeb8333"
+        colorLight: "#6eeb8333",
       });
       providerSet = true;
     }
@@ -45,11 +42,7 @@ function Editor({
     <CodeMirror
       value=""
       height="100%"
-      extensions={[
-        // StreamLanguage.define(lang),
-        lang,
-        yCollab(yText, provider.awareness, { undoManager })
-      ]}
+      extensions={[lang, yCollab(yText, provider.awareness, { undoManager })]}
     />
   );
 }

--- a/frontend/src/components/editor/Editor.tsx
+++ b/frontend/src/components/editor/Editor.tsx
@@ -1,5 +1,9 @@
 import CodeMirror from "@uiw/react-codemirror";
-import { javascript } from "@codemirror/lang-javascript";
+import { loadLanguage } from "@uiw/codemirror-extensions-langs";
+// import { javascript } from "@codemirror/lang-javascript";
+// import { java } from "@codemirror/lang-java";
+// import { python } from "@codemirror/lang-python";
+// import { StreamLanguage } from "@codemirror/language";
 import * as Y from "yjs";
 import React, { useEffect } from "react";
 import { WebsocketProvider } from "y-websocket-peerprep";
@@ -12,15 +16,22 @@ type Props = {
   provider: WebsocketProvider;
   undoManager: Y.UndoManager;
   nickname: string;
+  selectedLang: "javascript" | "java" | "python" | "go";
 };
 
-function Editor({ yText, provider, undoManager, nickname }: Props) {
+function Editor({
+  yText,
+  provider,
+  undoManager,
+  nickname,
+  selectedLang
+}: Props) {
   useEffect(() => {
     if (!providerSet) {
       provider.awareness.setLocalStateField("user", {
         name: nickname,
         color: "#6eeb83",
-        colorLight: "#6eeb8333",
+        colorLight: "#6eeb8333"
       });
       providerSet = true;
     }
@@ -28,13 +39,16 @@ function Editor({ yText, provider, undoManager, nickname }: Props) {
     return () => {};
   }, []);
 
+  const lang: any = loadLanguage(selectedLang);
+
   return (
     <CodeMirror
       value=""
       height="100%"
       extensions={[
-        javascript({ jsx: true }),
-        yCollab(yText, provider.awareness, { undoManager }),
+        // StreamLanguage.define(lang),
+        lang,
+        yCollab(yText, provider.awareness, { undoManager })
       ]}
     />
   );

--- a/frontend/src/components/editor/EditorLanguage.tsx
+++ b/frontend/src/components/editor/EditorLanguage.tsx
@@ -1,0 +1,34 @@
+import { Select, Text } from "@chakra-ui/react";
+import React, { ChangeEvent } from "react";
+
+type Props = {
+  selectedLang: string;
+  isDisabled: boolean;
+  changeLangHandler: (e: ChangeEvent<HTMLSelectElement>) => void;
+};
+
+function EditorLanguage({
+  selectedLang,
+  isDisabled,
+  changeLangHandler
+}: Props) {
+  return (
+    <>
+      <Text>Language: </Text>
+      <Select
+        value={selectedLang}
+        isDisabled={isDisabled}
+        onChange={changeLangHandler}
+        w="30%"
+      >
+        {["javascript", "go", "java", "python"].map((l) => (
+          <option value={l} key={l}>
+            {l}
+          </option>
+        ))}
+      </Select>
+    </>
+  );
+}
+
+export default EditorLanguage;

--- a/frontend/src/components/editor/EditorLanguage.tsx
+++ b/frontend/src/components/editor/EditorLanguage.tsx
@@ -10,7 +10,7 @@ type Props = {
 function EditorLanguage({
   selectedLang,
   isDisabled,
-  changeLangHandler
+  changeLangHandler,
 }: Props) {
   return (
     <>

--- a/frontend/src/pages/Session.tsx
+++ b/frontend/src/pages/Session.tsx
@@ -15,6 +15,7 @@ import SessionNavbar from "../components/ui/navbar/SessionNavbar";
 import Editor from "../components/editor/Editor";
 import useFixedToast from "../utils/hooks/useFixedToast";
 import { selectUser } from "../feature/user/userSlice";
+import { Language } from "../types";
 
 type Status = { status: "disconnected" | "connecting" | "connected" };
 type Nickname = { nickname: string };
@@ -28,12 +29,12 @@ function Session() {
   const {
     isOpen: isLeaveModalOpen,
     onOpen: onOpenLeaveModal,
-    onClose: onCloseLeaveModal
+    onClose: onCloseLeaveModal,
   } = useDisclosure();
   const {
     isOpen: isDisconnectModalOpen,
     onOpen: onOpenDisconnectModal,
-    onClose: onCloseDisconnectModal
+    onClose: onCloseDisconnectModal,
   } = useDisclosure();
   const toast = useFixedToast();
 
@@ -44,12 +45,10 @@ function Session() {
   const [undoManager, setundoManager] = useState<Y.UndoManager>();
 
   const [wsStatus, setWsStatus] = useState("Not Connected");
-  const [selectedLang, setSelectedLang] = useState<
-    "javascript" | "java" | "python" | "go"
-  >("javascript");
+  const [selectedLang, setSelectedLang] = useState<Language>("javascript");
 
   useEffect(() => {
-    /** Helper function to configure websocket with yDoc and custom events */
+    /** Helper function to configure websocket with yDoc and custom events. */
     const buildWSProvider = (yd: Y.Doc, params: { [x: string]: string }) => {
       // First 2 params builds the room session: ws://localhost:5001/ + ws
       const ws = new WebsocketProvider(
@@ -83,26 +82,20 @@ function Session() {
 
       ws.on("user_join", (joinedNickname: Nickname) => {
         toast.sendSuccessMessage("", {
-          title: `${joinedNickname.nickname} has joined the room!`
+          title: `${joinedNickname.nickname} has joined the room!`,
         });
       });
 
       ws.on("user_leave", (leftNickname: Nickname) => {
         toast.sendAlertMessage("", {
-          title: `${leftNickname.nickname} has left the room.`
+          title: `${leftNickname.nickname} has left the room.`,
         });
       });
 
-      ws.on(
-        "lang_change",
-        (languageChange: {
-          language: "javascript" | "java" | "python" | "go";
-        }) => {
-          const { language } = languageChange;
-          // console.log(language);
-          setSelectedLang(language);
-        }
-      );
+      ws.on("lang_change", (languageChange: { language: Language }) => {
+        const { language } = languageChange;
+        setSelectedLang(language);
+      });
 
       return ws;
     };
@@ -111,7 +104,7 @@ function Session() {
       // Yjs initialisation
       const tempyDoc = new Y.Doc();
       const params: { [x: string]: string } = {
-        room: roomToken === undefined ? "" : roomToken
+        room: roomToken === undefined ? "" : roomToken,
       };
 
       const tempprovider = buildWSProvider(tempyDoc, params);
@@ -132,7 +125,7 @@ function Session() {
   const changeLangHandler = (e: ChangeEvent<HTMLSelectElement>) => {
     const newLang = e.target.value;
     provider?.sendLanguageChange(newLang);
-    setSelectedLang(newLang as "javascript" | "java" | "python" | "go");
+    setSelectedLang(newLang as Language);
   };
 
   const leaveSessionHandler = () => {
@@ -177,6 +170,7 @@ function Session() {
             />
             {/* Other Quality of life options */}
           </Flex>
+
           {/* Editor */}
           {collabDefined && (
             <Editor

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,1 @@
+export type Language = "javascript" | "java" | "python" | "go";

--- a/scripts/gen-y-websocket.sh
+++ b/scripts/gen-y-websocket.sh
@@ -6,6 +6,6 @@ npm pack --pack-destination ../frontend
 
 cd ../frontend
 echo "Installing package"
-npm i y-websocket-peerprep-1.4.5.tgz
+npm i --force y-websocket-peerprep-1.4.5.tgz
 
 echo "Done"

--- a/y-websocket/dist/src/y-websocket.d.ts
+++ b/y-websocket/dist/src/y-websocket.d.ts
@@ -129,6 +129,7 @@ export class WebsocketProvider extends Observable<string> {
 	destroy(): void;
 	sendJoinMessage(nickname: string): void;
 	sendDisconnectMessage(nickname: string): void;
+	sendLanguageChange(language: string): void;
 }
 import { Observable } from "lib0/observable";
 import * as Y from "yjs";

--- a/y-websocket/src/y-websocket.js
+++ b/y-websocket/src/y-websocket.js
@@ -24,6 +24,7 @@ export const messageAuth = 2
 // Custom events for peerPrep
 export const USER_JOIN = 4
 export const USER_LEAVE = 5
+export const LANG_CHANGE = 6
 
 /**
  *                       encoder,          decoder,          provider,          emitSynced, messageType
@@ -113,6 +114,14 @@ messageHandlers[USER_LEAVE] = (_encoder, decoder, provider, _emitSynced, _messag
   console.log('nickname: ', nickname)
   provider.emit('user_leave', [{ nickname }])
 }
+
+messageHandlers[LANG_CHANGE] = (_encoder, decoder, provider, _emitSynced, _messageType) => {
+  console.log('[Rcv]: Language Changed')
+  const language = decoding.readVarString(decoder)
+  console.log(language)
+  provider.emit('lang_change', [{language}])
+}
+
 
 // @todo - this should depend on awareness.outdatedTime
 const messageReconnectTimeout = 30000
@@ -520,6 +529,13 @@ export class WebsocketProvider extends Observable {
     const encoder = encoding.createEncoder()
     encoding.writeVarUint(encoder, USER_LEAVE)
     encoding.writeVarString(encoder, nickname)
+    broadcastMessage(this, encoding.toUint8Array(encoder))
+  }
+
+  sendLanguageChange(/** @type {string} */ language) {
+    const encoder = encoding.createEncoder()
+    encoding.writeVarUint(encoder, LANG_CHANGE)
+    encoding.writeVarString(encoder, language)
     broadcastMessage(this, encoding.toUint8Array(encoder))
   }
 }


### PR DESCRIPTION
# Changes
This PR allows the user to switch between programming languages (with synchronization) with the included syntax highlighting.

# Note
To test this branch, run `npm run-script gen-y-websocket` to retrieve the latest changes in `y-websocket`.

This will not replace the contents of the editor yet.

Supported languages: `javascript` (default), `java`, `go`, `python`

# Prerequisites
- #131 

# Related Issues
- Closes #122

## Screenshots
Javascript (Default)
![image](https://user-images.githubusercontent.com/13163631/193411163-3bf8950e-2919-40f2-a1c2-df4dcaed653f.png)

Java 
![image](https://user-images.githubusercontent.com/13163631/193411217-a20dbc35-5fca-40eb-8501-0741ecaca047.png)

Go
![image](https://user-images.githubusercontent.com/13163631/193411372-be1e3fb1-52fd-48c4-91ed-0e81878f7616.png)

Python
![image](https://user-images.githubusercontent.com/13163631/193411310-8a4c1dee-c5f2-4922-8670-91f47034a3d5.png)

