### PR TITLE
Fix Flipped Ternary Operator in Frontend

### DIFF
--- a/frontend/src/components/history/HistorySection.tsx
+++ b/frontend/src/components/history/HistorySection.tsx
@@ -14,11 +14,11 @@ function HistorySection({ submission }: Props) {
       </Heading>
       <Divider />
       {submission ? (
-        <LoadingSection message="Loading Submission..." />
-      ) : (
         <Code width="100%" overflow="scroll">
           {submission}
         </Code>
+      ) : (
+        <LoadingSection message="Loading Submission..." />
       )}
     </VStack>
   );


### PR DESCRIPTION
## Changes
This fix changes a mistake made during refactoring, which inverted a conditional render in the history page.