### PR TITLE
Fix Token Invalidation and Refresh After Password and/or Nickname Change

### DIFF
--- a/frontend/src/components/form/ChangeNicknameForm.tsx
+++ b/frontend/src/components/form/ChangeNicknameForm.tsx
@@ -31,6 +31,7 @@ function ChangeNicknameForm() {
     register,
     handleSubmit,
     formState: { errors },
+    reset,
   } = useForm({ resolver: yupResolver(CHANGE_NICKNAME_VALIDTOR) });
 
   const toast = useFixedToast();
@@ -68,6 +69,7 @@ function ChangeNicknameForm() {
         dispatch(changeNickname({ user: newUser }));
 
         toast.sendSuccessMessage("Your nickname is changed!");
+        reset();
       })
       .catch((err) => {
         toast.sendErrorMessage(err.message);

--- a/frontend/src/components/form/ChangePasswordForm.tsx
+++ b/frontend/src/components/form/ChangePasswordForm.tsx
@@ -23,11 +23,11 @@ import PasswordInput from "../ui/form/PasswordInput";
 import { SET_PW_VALIDATOR } from "../../constants/validators";
 
 function ChangePasswordForm() {
-
   const {
     register,
     handleSubmit,
     formState: { errors },
+    reset,
   } = useForm({ resolver: yupResolver(SET_PW_VALIDATOR) });
 
   const toast = useFixedToast();
@@ -55,6 +55,7 @@ function ChangePasswordForm() {
         }
 
         toast.sendSuccessMessage("Your password is changed!");
+        reset();
       })
       .catch((err) => {
         toast.sendErrorMessage(err.message);

--- a/frontend/src/components/form/ChangePasswordForm.tsx
+++ b/frontend/src/components/form/ChangePasswordForm.tsx
@@ -12,8 +12,6 @@ import {
   SubmitHandler,
   useForm,
 } from "react-hook-form";
-import { useNavigate } from "react-router-dom";
-import { useDispatch } from "react-redux";
 import { yupResolver } from "@hookform/resolvers/yup";
 import axios from "../../axios";
 import useFixedToast from "../../utils/hooks/useFixedToast";
@@ -21,14 +19,10 @@ import {
   ChangePasswordRequest,
   ChangePasswordResponse,
 } from "../../proto/user-service";
-import { reset } from "../../feature/matching/matchingSlice";
-import { logout } from "../../feature/user/userSlice";
 import PasswordInput from "../ui/form/PasswordInput";
 import { SET_PW_VALIDATOR } from "../../constants/validators";
 
 function ChangePasswordForm() {
-  const navigate = useNavigate();
-  const dispatch = useDispatch();
 
   const {
     register,
@@ -60,13 +54,7 @@ function ChangePasswordForm() {
           throw new Error(errorMessage);
         }
 
-        toast.sendSuccessMessage(
-          "Your password is changed! You will need to login again!"
-        );
-
-        dispatch(reset());
-        dispatch(logout());
-        navigate("/login", { replace: true });
+        toast.sendSuccessMessage("Your password is changed!");
       })
       .catch((err) => {
         toast.sendErrorMessage(err.message);

--- a/user-service/src/auth/authentication_agent_types.d.ts
+++ b/user-service/src/auth/authentication_agent_types.d.ts
@@ -1,7 +1,7 @@
 declare interface IAuthenticationAgent {
   createToken(payload: Object): Promise<TokenPair>;
   invalidateToken(token: TokenPair): Promise<boolean>;
-  invalidateTokensBeforeTime(username: string, timestamp: number): void;
+  invalidateTokensBeforeTime(username: string, timestamp: number): Promise<void>;
 }
 
 declare type TokenUserData = {

--- a/user-service/src/controller/user_service_controller.ts
+++ b/user-service/src/controller/user_service_controller.ts
@@ -78,7 +78,7 @@ class UserServiceApi implements ApiService<IUserService> {
         ConsumeResetTokenResponse,
       ),
       changeNickname: fromApiHandler(
-        new ChangeNicknameHandler(crudLoopback),
+        new ChangeNicknameHandler(crudLoopback, authService, hashAgent),
         ChangeNicknameRequest,
         ChangeNicknameResponse,
       ),

--- a/user-service/src/controller/user_service_handlers/change_nickname_handler.ts
+++ b/user-service/src/controller/user_service_handlers/change_nickname_handler.ts
@@ -13,15 +13,25 @@ import { IUserCrudService } from '../../proto/user-crud-service.grpc-server';
 import { PasswordUser, User } from '../../proto/types';
 import GatewayConstants from '../../utils/gateway_constants';
 import { ILoopbackServiceChannel } from '../../api_server/loopback_server_types';
+import { IAuthenticationAgent, TokenPair } from '../../auth/authentication_agent_types';
+import IHashAgent from '../../auth/hash_agent_types';
 
 class ChangeNicknameHandler
 implements IApiHandler<ChangeNicknameRequest, ChangeNicknameResponse> {
   rpcLoopback: ILoopbackServiceChannel<IUserCrudService>;
 
+  authAgent: IAuthenticationAgent;
+
+  hashAgent: IHashAgent;
+
   constructor(
     rpcLoopback: ILoopbackServiceChannel<IUserCrudService>,
+    authAgent: IAuthenticationAgent,
+    hashAgent: IHashAgent,
   ) {
     this.rpcLoopback = rpcLoopback;
+    this.authAgent = authAgent;
+    this.hashAgent = hashAgent;
   }
 
   async handle(request: ApiRequest<ChangeNicknameRequest>):
@@ -69,10 +79,33 @@ implements IApiHandler<ChangeNicknameRequest, ChangeNicknameResponse> {
       );
     }
 
-    return ChangeNicknameHandler.buildHeaderlessResponse({
-      errorCode: ChangeNicknameErrorCode.CHANGE_NICKNAME_ERROR_NONE,
-      errorMessage: '',
-    });
+    user.userInfo.nickname = newNickname;
+
+    let token: TokenPair;
+    try {
+      token = await this.authAgent.createToken({
+        username: user.userInfo?.username,
+        nickname: user.userInfo?.nickname,
+      });
+    } catch {
+      return ChangeNicknameHandler.buildErrorResponse(
+        ChangeNicknameErrorCode.CHANGE_NICKNAME_ERROR_INTERNAL_ERROR,
+        'Internal Error',
+      );
+    }
+
+    return {
+      response: {
+        errorCode: ChangeNicknameErrorCode.CHANGE_NICKNAME_ERROR_NONE,
+        errorMessage: '',
+      },
+      headers: {
+        'Set-Cookie': [
+          `${GatewayConstants.COOKIE_SESSION_TOKEN}=${token.sessionToken}; Path=/`,
+          `${GatewayConstants.COOKIE_REFRESH_TOKEN}=${token.refreshToken}; Path=/; HttpOnly`,
+        ],
+      },
+    };
   }
 
   static validateRequest(request: ChangeNicknameRequest): (ValidatedRequest | Error) {

--- a/user-service/src/controller/user_service_handlers/change_nickname_handler.ts
+++ b/user-service/src/controller/user_service_handlers/change_nickname_handler.ts
@@ -79,6 +79,18 @@ implements IApiHandler<ChangeNicknameRequest, ChangeNicknameResponse> {
       );
     }
 
+    try {
+      await this.authAgent.invalidateTokensBeforeTime(
+        user.userInfo.username,
+        Math.floor(new Date().getTime() / 1000) - 1,
+      );
+    } catch {
+      return ChangeNicknameHandler.buildErrorResponse(
+        ChangeNicknameErrorCode.CHANGE_NICKNAME_ERROR_INTERNAL_ERROR,
+        'Could not invalidate old tokens',
+      );
+    }
+
     user.userInfo.nickname = newNickname;
 
     let token: TokenPair;

--- a/user-service/src/controller/user_service_handlers/change_password_handler.ts
+++ b/user-service/src/controller/user_service_handlers/change_password_handler.ts
@@ -83,7 +83,7 @@ implements IApiHandler<ChangePasswordRequest, ChangePasswordResponse> {
     try {
       await this.authAgent.invalidateTokensBeforeTime(
         user.userInfo.username,
-        Math.floor(new Date().getTime() / 1000),
+        Math.floor(new Date().getTime() / 1000) - 1,
       );
     } catch {
       return ChangePasswordHandler.buildErrorResponse(


### PR DESCRIPTION
## Changes 

- Invalidate JWT tokens after profile information has changed

## Related Issues
- Closes #209 